### PR TITLE
Fix key generation

### DIFF
--- a/rand_bytes.c
+++ b/rand_bytes.c
@@ -14,7 +14,7 @@ int RAND_bytes(unsigned char *buf, int num)
 	close(fd);
 
 	if (r != num)
-		return 1;
-	else
 		return 0;
+	else
+		return 1;
 }


### PR DESCRIPTION
Generating keys is currently broken:

```
$ ./signify -G -p pub -s secret
signify: Couldn't obtain random bytes
$ strace -e open,read !!
[...]
open("/dev/urandom", O_RDONLY)          = 3
read(3, "d[jH#5\352(\217\24\362\363A[i\355\230\251\250,\362!G\0328\374\20n\7\"\217`"..., 40) = 40
signify: Couldn't obtain random bytes
+++ exited with 1 +++
```

The read("/dev/urandom",...) from RAND_bytes() completes just fine. The problem
seems to be that arc4random.c expects OpenSSL return value semantics on
RAND_bytes. e478f1a5265 wanted to address this but mixed up success and error
cases (OpenSSL uses 1 for success and 0 or -1 for errors).
